### PR TITLE
fix: should set root correctly

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -20,6 +20,7 @@ module.exports = appInfo => {
    */
   config.swigPagelet = {
     layout: 'layout/layout.tpl',
+    root: path.join(appInfo.baseDir, 'app'),
     manifest: path.join(appInfo.baseDir, 'config/manifest.json'),
   };
 


### PR DESCRIPTION
https://github.com/scrat-team/scrat-swig/blob/master/index.js#L24

scrat-swig 的 root 应该为 app 目录下，否则会导致 release 之后，找不到文件~